### PR TITLE
update vignette, using new spatialdata.data methods

### DIFF
--- a/R/plotLabel.R
+++ b/R/plotLabel.R
@@ -31,8 +31,10 @@
 #' 
 #' # coloring by 'colData'
 #' n <- length(unique(t$id))
-#' pal <- hcl.colors(n, "Spectral")
-#' p + plotLabel(x, i, "id", pal=pal)
+#' # TODO: did a small fix to color scheme below, will fix example later
+#' # pal <- hcl.colors(n, "Spectral")
+#' pal_d <- hcl.colors(10, "Spectral")
+#' p + plotLabel(x, i, "id", pal=pal_d)
 #' 
 #' # coloring by 'assay' data
 #' p + plotLabel(x, i, "channel_1_sum")

--- a/man/plotLabel.Rd
+++ b/man/plotLabel.Rd
@@ -55,8 +55,10 @@ table(x) <- t
 
 # coloring by 'colData'
 n <- length(unique(t$id))
-pal <- hcl.colors(n, "Spectral")
-p + plotLabel(x, i, "id", pal=pal)
+# TODO: did a small fix to color scheme below, will fix example later
+# pal <- hcl.colors(n, "Spectral")
+pal_d <- hcl.colors(10, "Spectral")
+p + plotLabel(x, i, "id", pal=pal_d)
 
 # coloring by 'assay' data
 p + plotLabel(x, i, "channel_1_sum")

--- a/tests/testthat/test-plotImage.R
+++ b/tests/testthat/test-plotImage.R
@@ -56,8 +56,7 @@ test_that(".check_cl", {
 })
 
 dir.create(td <- tempfile())
-pa <- unzip_spd_demo(zipname="steinbock_io.zip", dest=td, source="biocOSN")
-x <- readSpatialData(pa, images=1, labels=FALSE, points=FALSE, shapes=FALSE, tables=FALSE)
+(x <- SpatialData.data::MulticancerSteinbock())
 a <- data(image(x)[seq_len(3), seq_len(100), seq_len(100)], 1)
 
 test_that(".get_img_dt", {

--- a/vignettes/SpatialData.plot.Rmd
+++ b/vignettes/SpatialData.plot.Rmd
@@ -168,10 +168,7 @@ Such labels could be morphological regions annotated by pathologists.
 
 ```{r merfish-read}
 dir.create(td <- tempfile())
-pa <- unzip_spd_demo(
-    zipname="merfish.zarr.zip", 
-    dest=td, source="biocOSN")
-(x <- readSpatialData(pa, anndataR=FALSE))
+(x <- MouseBrainMERFISH(td))
 ```
 
 There are only `r length(SpatialData::shape(x, "cells"))` cells, but 
@@ -207,10 +204,7 @@ Mouse intestine, 1GB; 4 image resolutions and 3 shapes at 2, 8, and 16 $\mu$m.
 
 ```{r visiumhd-read}
 dir.create(td <- tempfile())
-pa <- unzip_spd_demo(
-    zipname="visium_hd_3.0.0_io.zip", 
-    dest=td, source="biocOSN")
-(x <- readSpatialData(pa, images=4, shapes=3, tables=FALSE))
+(x <- MouseIntestineVisHD(td))
 ```
 
 ```{r visiumhd-plot}
@@ -226,10 +220,7 @@ Colorectal carcinoma, 25 MB; no shapes, no points.
 
 ```{r mibitof-read}
 dir.create(td <- tempfile())
-pa <- unzip_spd_demo(
-    zipname="mibitof.zip", 
-    dest=td, source="biocOSN")
-(x <- readSpatialData(pa, anndataR=FALSE))
+(x <- ColorectalCarcinomaMIBITOF(td)) 
 ```
 
 ```{r mibitof-plot, fig.width=10, fig.height=3}
@@ -246,10 +237,7 @@ Small lung adenocarcinoma, 250 MB; 1 image, 2 labels, 2 tables.
 
 ```{r mcmicro-read}
 dir.create(td <- tempfile())
-pa <- unzip_spd_demo(
-    zipname="mcmicro_io.zip", 
-    dest=td, source="biocOSN")
-(x <- readSpatialData(pa, anndataR=FALSE))
+x <- LungAdenocarcinomaMCMICRO(td)
 ```
 
 Getting channel names for the image:
@@ -273,34 +261,32 @@ plotSpatialData() + plotImage(x,
 
 ```{r steinbock-read}
 dir.create(td <- tempfile())
-pa <- unzip_spd_demo(
-    zipname="steinbock_io.zip", 
-    dest=td, source="biocOSN")
-x <- readSpatialData(pa, anndataR=FALSE)
+# x <- MulticancerSteinbock(td)
+# TODO: readSpatialData fails here, commenting out below code
 ```
 
 ### channels
 
 ```{r steinbock-ch}
-plotSpatialData() + plotImage(x,
-    i="Patient3_003_image",
-    ch=c(6, 22, 39),
-    c=c("blue", "cyan", "yellow"))
+# plotSpatialData() + plotImage(x,
+#     i="Patient3_003_image",
+#     ch=c(6, 22, 39),
+#     c=c("blue", "cyan", "yellow"))
 ```
 
 ### contrasts
 
 ```{r steinbock-cl, fig.width=9, fig.height=3}
-i <- image(x, "Patient3_003_image")
-image(x, "crop") <- i[, 200:400, 200:400]
-lapply(list(c(0.2, 1), c(0, 0.8), c(0, 1.2)), \(.) {
-    plotSpatialData() + plotImage(x, 
-        i="crop", 
-        ch=c(6, 22, 39), 
-        cl=list(1, 1, .),
-        c=c("blue", "cyan", "yellow")) +
-        ggtitle(sprintf("[%s, %s]", .[1], .[2]))
-}) |> wrap_plots(nrow=1) + plot_layout(guides="collect")
+# i <- image(x, "Patient3_003_image")
+# image(x, "crop") <- i[, 200:400, 200:400]
+# lapply(list(c(0.2, 1), c(0, 0.8), c(0, 1.2)), \(.) {
+#     plotSpatialData() + plotImage(x, 
+#         i="crop", 
+#         ch=c(6, 22, 39), 
+#         cl=list(1, 1, .),
+#         c=c("blue", "cyan", "yellow")) +
+#         ggtitle(sprintf("[%s, %s]", .[1], .[2]))
+# }) |> wrap_plots(nrow=1) + plot_layout(guides="collect")
 ```
 
 # Masking

--- a/vignettes/SpatialData.plot.Rmd
+++ b/vignettes/SpatialData.plot.Rmd
@@ -167,8 +167,7 @@ In this example data, we do not have a `label` for the `shape` polygons.
 Such labels could be morphological regions annotated by pathologists.
 
 ```{r merfish-read}
-dir.create(td <- tempfile())
-(x <- MouseBrainMERFISH(td))
+(x <- MouseBrainMERFISH())
 ```
 
 There are only `r length(SpatialData::shape(x, "cells"))` cells, but 
@@ -203,8 +202,7 @@ plotSpatialData() + plotImage(x) + bb | plotSpatialData() + plotImage(y)
 Mouse intestine, 1GB; 4 image resolutions and 3 shapes at 2, 8, and 16 $\mu$m.
 
 ```{r visiumhd-read}
-dir.create(td <- tempfile())
-(x <- MouseIntestineVisHD(td))
+(x <- MouseIntestineVisHD())
 ```
 
 ```{r visiumhd-plot}
@@ -219,8 +217,7 @@ plotSpatialData() + plotImage(x) + bb | plotSpatialData() + plotImage(y)
 Colorectal carcinoma, 25 MB; no shapes, no points.
 
 ```{r mibitof-read}
-dir.create(td <- tempfile())
-(x <- ColorectalCarcinomaMIBITOF(td)) 
+(x <- ColorectalCarcinomaMIBITOF()) 
 ```
 
 ```{r mibitof-plot, fig.width=10, fig.height=3}
@@ -236,8 +233,7 @@ wrap_plots(nrow=1, lapply(seq(3), \(.)
 Small lung adenocarcinoma, 250 MB; 1 image, 2 labels, 2 tables.
 
 ```{r mcmicro-read}
-dir.create(td <- tempfile())
-x <- LungAdenocarcinomaMCMICRO(td)
+x <- LungAdenocarcinomaMCMICRO()
 ```
 
 Getting channel names for the image:
@@ -260,33 +256,31 @@ plotSpatialData() + plotImage(x,
 4 different cancers (SCCHN, BCC, NSCLC, CRC), 820 MB; 14 images, 14 labels, 1 table.
 
 ```{r steinbock-read}
-dir.create(td <- tempfile())
-# x <- MulticancerSteinbock(td)
-# TODO: readSpatialData fails here, commenting out below code
+x <- MulticancerSteinbock()
 ```
 
 ### channels
 
 ```{r steinbock-ch}
-# plotSpatialData() + plotImage(x,
-#     i="Patient3_003_image",
-#     ch=c(6, 22, 39),
-#     c=c("blue", "cyan", "yellow"))
+plotSpatialData() + plotImage(x,
+    i="Patient3_003_image",
+    ch=c(6, 22, 39),
+    c=c("blue", "cyan", "yellow"))
 ```
 
 ### contrasts
 
 ```{r steinbock-cl, fig.width=9, fig.height=3}
-# i <- image(x, "Patient3_003_image")
-# image(x, "crop") <- i[, 200:400, 200:400]
-# lapply(list(c(0.2, 1), c(0, 0.8), c(0, 1.2)), \(.) {
-#     plotSpatialData() + plotImage(x, 
-#         i="crop", 
-#         ch=c(6, 22, 39), 
-#         cl=list(1, 1, .),
-#         c=c("blue", "cyan", "yellow")) +
-#         ggtitle(sprintf("[%s, %s]", .[1], .[2]))
-# }) |> wrap_plots(nrow=1) + plot_layout(guides="collect")
+i <- image(x, "Patient3_003_image")
+image(x, "crop") <- i[, 200:400, 200:400]
+lapply(list(c(0.2, 1), c(0, 0.8), c(0, 1.2)), \(.) {
+    plotSpatialData() + plotImage(x,
+        i="crop",
+        ch=c(6, 22, 39),
+        cl=list(1, 1, .),
+        c=c("blue", "cyan", "yellow")) +
+        ggtitle(sprintf("[%s, %s]", .[1], .[2]))
+}) |> wrap_plots(nrow=1) + plot_layout(guides="collect")
 ```
 
 # Masking


### PR DESCRIPTION
@vjcitn currently `x <- MulticancerSteinbock(td)` does not work, here is the error below. Perhaps the object is outdated given new validations in anndata object ? 

```
Error in py_call_impl(callable, call_args$unnamed, call_args$named) : 
  spatialdata._core.validation.ValidationError: Cannot construct SpatialData object, input contains invalid elements.
For renaming, please see the discussion here https://github.com/scverse/spatialdata/discussions/707 .
  obs/image: Key `image` is not unique, or another case-variant of it exists.
  var/Tube Number: Name must contain only alphanumeric characters, underscores, dots and hyphens.
  var/Antibody Clone: Name must contain only alphanumeric characters, underscores, dots and hyphens.
  var/Stock Concentration: Name must contain only alphanumeric characters, underscores, dots and hyphens.
  var/Final Concentration / Dilution: Name must contain only alphanumeric characters, underscores, dots and hyphens.
  var/uL to add: Name must contain only alphanumeric characters, underscores, dots and hyphens.
Run `reticulate::py_last_error()` for details.
```