### PR TITLE
Fix transpose in normalization step

### DIFF
--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -206,7 +206,7 @@ setMethod("plotImage", "SpatialData", \(x, i=1, j=1, k=NULL, ch=NULL, c=NULL, cl
     wh <- .get_wh(y)
     if (.is_rgb(y)) {
         # RGB: we plot everything by default and we don't normalize
-        ch <- ch %||% c("r", "g", "b")
+        ch <- ch %||% channels(y)
         cl <- cl %||% c(0, 1/3)
     }
     df <- .df_i(y, k, ch, c, cl)

--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -210,7 +210,7 @@ setMethod("plotImage", "SpatialData", \(x, i=1, j=1, k=NULL, ch=NULL, c=NULL, cl
         cl <- cl %||% c(0, 1/3)
     }
     df <- .df_i(y, k, ch, c, cl)
-    pal <- if (is.null(c)) .DEFAULT_COLORS else c
+    pal <- c %||% .DEFAULT_COLORS
     if (dim(y)[1] > 1) {
         nms <- unlist(channels(y))[idx <- .ch_idx(y, ch)]
         pal <- pal[seq_along(idx)]; names(pal) <- nms

--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -101,8 +101,8 @@ NULL
         cl <- matrix(cl, ncol=2)
     }
     colors_rgb <- col2rgb(c)
-    normed_a <- (t(linear_a) - cl[, 1]) / (cl[, 2] - cl[, 1])
-    flat_img <- tcrossprod(colors_rgb, normed_a) / d
+    normed_a <- (linear_a - cl[, 1]) / (cl[, 2] - cl[, 1])
+    flat_img <- (colors_rgb %*% normed_a) / d
     flat_img |> 
         t() |> 
         farver::encode_colour() |> 

--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -211,7 +211,7 @@ setMethod("plotImage", "SpatialData", \(x, i=1, j=1, k=NULL, ch=NULL, c=NULL, cl
     }
     df <- .df_i(y, k, ch, c, cl)
     pal <- c %||% .DEFAULT_COLORS
-    if (dim(y)[1] > 1) {
+    if (dim(y)[1] > 1 && !.is_rgb(y)) {
         nms <- unlist(channels(y))[idx <- .ch_idx(y, ch)]
         pal <- pal[seq_along(idx)]; names(pal) <- nms
     }

--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -142,7 +142,6 @@ NULL
 #' @importFrom SpatialData channels
 #' @noRd
 .ch_idx <- \(x, ch) {
-    if (.is_rgb(x)) return(seq_len(3))
     if (is.null(ch)) return(1)
     lbs <- channels(x)
     if (all(ch %in% lbs)) {
@@ -162,6 +161,11 @@ NULL
 #' @importFrom SpatialData data_type
 .df_i <- \(x, k=NULL, ch=NULL, c=NULL, cl=NULL) {
     a <- .get_multiscale_data(x, k)
+    if (.is_rgb(x)) {
+        # RGB: we plot everything by default and we don't normalize
+        ch <- ch %||% c("r", "g", "b")
+        cl <- cl %||% c(0, 1/3)
+    }
     a <- a[.ch_idx(x, ch),,,drop=FALSE]
     a <- .norm_ia(a, data_type(x))
     a <- .prep_ia(a, c, cl)

--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -161,11 +161,6 @@ NULL
 #' @importFrom SpatialData data_type
 .df_i <- \(x, k=NULL, ch=NULL, c=NULL, cl=NULL) {
     a <- .get_multiscale_data(x, k)
-    if (.is_rgb(x)) {
-        # RGB: we plot everything by default and we don't normalize
-        ch <- ch %||% c("r", "g", "b")
-        cl <- cl %||% c(0, 1/3)
-    }
     a <- a[.ch_idx(x, ch),,,drop=FALSE]
     a <- .norm_ia(a, data_type(x))
     a <- .prep_ia(a, c, cl)
@@ -209,6 +204,11 @@ setMethod("plotImage", "SpatialData", \(x, i=1, j=1, k=NULL, ch=NULL, c=NULL, cl
         j <- CTname(y)[j]
     y <- transform(y, j)
     wh <- .get_wh(y)
+    if (.is_rgb(y)) {
+        # RGB: we plot everything by default and we don't normalize
+        ch <- ch %||% c("r", "g", "b")
+        cl <- cl %||% c(0, 1/3)
+    }
     df <- .df_i(y, k, ch, c, cl)
     pal <- if (is.null(c)) .DEFAULT_COLORS else c
     if (dim(y)[1] > 1) {


### PR DESCRIPTION
`dim(linear_a)` is already of `c(d, nb_of_pixels)`. So we shouldn't transpose (and transpose back) to normalize each channel by `cl`. 

This should fix the strange square artifacts we could sometimes see.

After this PR:

<img width="658" height="781" alt="image" src="https://github.com/user-attachments/assets/7e1b469b-caf9-408a-a906-8acbd34c3f18" />

<img width="658" height="508" alt="image" src="https://github.com/user-attachments/assets/74d70904-72c5-4f45-90f0-d4d3eb477477" />
