### PR TITLE
Flip image to match other layers

### DIFF
--- a/R/plotFrame.R
+++ b/R/plotFrame.R
@@ -82,7 +82,7 @@ NULL
     list(
         do.call(geom_sf, c(list(data=df, mapping=aes), c(dot))),
         theme(legend.key.size=unit(0.5, "lines")),
-        coord_sf(expand=FALSE, reverse="y"))
+        coord_sf(expand=FALSE))
 }
 #' @export
 #' @rdname plotFrame

--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -163,6 +163,12 @@ NULL
     a <- .get_multiscale_data(x, k)
     a <- a[.ch_idx(x, ch),,,drop=FALSE]
     a <- .norm_ia(a, data_type(x))
+    # We later use `annotation_raster()`, which plots the array the same way it is printed,
+    # i.e., with the row 1 at the top, which doesn't match the rest of the ecosystem,
+    # so we mirror the image horizontally.
+    # FIXME: at some point, we would like to use `SpatialData::mirror()` directly in the 
+    # `plotImage()` for this but it's currently not lazy and super slow.
+    a <- a[, rev(seq_len(dim(a)[2])), , drop=FALSE]
     a <- .prep_ia(a, c, cl)
 }
 


### PR DESCRIPTION
Alternative to #23 

``` r
library(SpatialData.plot)
#> Loading required package: SpatialData
#> 
#> Attaching package: 'SpatialData'
#> The following object is masked from 'package:stats':
#> 
#>     filter
#> The following object is masked from 'package:utils':
#> 
#>     data
#> The following objects are masked from 'package:base':
#> 
#>     labels, scale, sequence, table, transform

sd <- SpatialData.data::LungAdenocarcinomaMCMICRO()
sp <- crop(sd, list(
  xmin=0, xmax=2500,
  ymin=600, ymax=3200))
# original
plotSpatialData() + plotImage(sd,
  ch=c("CD16", "CD45", "FOXP3", "DNA_7", "ECAD", "SMA"),
  c=c("cyan", "magenta", "yellow", "blue", "green", "red"))
```

![](https://i.imgur.com/nkjqH1f.png)<!-- -->

``` r
# cropped
plotSpatialData() + plotImage(sp,
  ch=c("CD16", "CD45", "FOXP3", "DNA_7", "ECAD", "SMA"),
  c=c("cyan", "magenta", "yellow", "blue", "green", "red"))
```

![](https://i.imgur.com/j9AwTsx.png)<!-- -->

<sup>Created on 2026-05-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>