### PR TITLE
Flip coordinates in plotImage()

### DIFF
--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -221,4 +221,4 @@ setMethod("plotImage", "SpatialData", \(x, i=1, j=1, k=NULL, ch=NULL, c=NULL, cl
 #' @export
 #' @rdname plotImage
 #' @importFrom ggplot2 ggplot scale_y_reverse coord_fixed
-plotSpatialData <- \() ggplot() + coord_fixed() + .theme 
+plotSpatialData <- \() ggplot() + scale_y_reverse() + coord_fixed() + .theme 

--- a/R/plotImage.R
+++ b/R/plotImage.R
@@ -222,3 +222,7 @@ setMethod("plotImage", "SpatialData", \(x, i=1, j=1, k=NULL, ch=NULL, c=NULL, cl
 #' @rdname plotImage
 #' @importFrom ggplot2 ggplot scale_y_reverse coord_fixed
 plotSpatialData <- \() ggplot() + scale_y_reverse() + coord_fixed() + .theme 
+# `annotation_raster` plots the array the same way it is printed, i.e., with the
+# row 1 at the top, which means we need to flip the y-axis to have the correct axis labels.
+# We tried flipping the image itself but it means everything gets out of alignement if
+# the user sets `scale_y_reverse()` themselves.


### PR DESCRIPTION
Alternative to #21 

``` r
library(SpatialData.plot)
#> Loading required package: SpatialData
#> 
#> Attaching package: 'SpatialData'
#> The following object is masked from 'package:stats':
#> 
#>     filter
#> The following object is masked from 'package:utils':
#> 
#>     data
#> The following objects are masked from 'package:base':
#> 
#>     labels, scale, sequence, table, transform

sd <- SpatialData.data::LungAdenocarcinomaMCMICRO()
sp <- crop(sd, list(
  xmin=0, xmax=2500,
  ymin=600, ymax=3200))
# original
plotSpatialData() + plotImage(sd,
  ch=c("CD16", "CD45", "FOXP3", "DNA_7", "ECAD", "SMA"),
  c=c("cyan", "magenta", "yellow", "blue", "green", "red"))
```

![](https://i.imgur.com/ppPvcRl.png)<!-- -->

``` r
# cropped
plotSpatialData() + plotImage(sp,
  ch=c("CD16", "CD45", "FOXP3", "DNA_7", "ECAD", "SMA"),
  c=c("cyan", "magenta", "yellow", "blue", "green", "red"))
```

![](https://i.imgur.com/k1i9nQL.png)<!-- -->

<sup>Created on 2026-05-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>